### PR TITLE
Add location for /consolehelp/ and disable WLProxySSL for help

### DIFF
--- a/chips-http.conf
+++ b/chips-http.conf
@@ -17,7 +17,7 @@ ExpiresByType text/css "access plus 10 hours"
 </IfModule>
 
 <LocationMatch "(/chips/cff|/chips/cff/servlet/.+|/chips/cff.+|/chips/servlet/.+|/chips/utilities/.+|/chips-restService/.+|/chips-queuedRestService/.+)$">
-  SetHandler weblogic-handler
+  WLSRequest ON
 </LocationMatch>
 
 Listen 81
@@ -29,9 +29,13 @@ Listen 81
     WebLogicPort 7001
     ConnectTimeoutSecs 30
     WLTempDir /tmp
-    WLProxySSL ON
   </IfModule>
-  <LocationMatch ".*">
-    SetHandler weblogic-handler
+  <LocationMatch "^/console/*">
+    WLSRequest ON
+    WLProxySSL ON
+  </LocationMatch>
+  <LocationMatch "^/consolehelp/*">
+    WLSRequest ON
+    WLProxySSL OFF
   </LocationMatch>
 </VirtualHost>


### PR DESCRIPTION
The WebLogic console help window wasn't opening correctly as the help doesn't work with WLProxySSL active, so this adds a separate location for /consolehelp/ and turns WLProxySSL off for that.

Also replaced SetHandler with the more recent WLSRequest directive.

Resolves: https://companieshouse.atlassian.net/browse/CM-911