### PR TITLE
Copy and extract CHIPSviewer ViewONE applet tar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:1.0.0 as builder
 
 COPY apache*.tar .
+COPY CHIPSviewer*.tar .
 
-RUN tar -xvf apache*.tar
+RUN tar -xvf apache*.tar && \
+    cd apache && \
+    tar -xvf ../CHIPSviewer*.tar
 
 FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-apache:1.1.0
 


### PR DESCRIPTION
We have found an issue whilst testing CHIPS and FES that is due to the way the ViewONE java applet is currently served from a non-ssl URL.  To resolve the issue, we need to include the applet code in the apache container, like we do for the CHIPS static content (css/images/js etc)

This adds the applet to the container as part of the docker build.  It expects the concourse pipeline to have placed the CHIPSviewer tar into the build context.

As well as also updating the pipeline, we need to update CHIPS to use a relative URL for loading the applet for just the cloud servers (wlserver1,2,3 &4).

Resolves: https://companieshouse.atlassian.net/browse/CM-1398