### PR TITLE
Truncate apache logs automatically

### DIFF
--- a/chips-http.conf
+++ b/chips-http.conf
@@ -1,6 +1,6 @@
 ServerName apache
-ErrorLog /usr/local/apache2/exportedlogs/apache/error.log
-CustomLog /usr/local/apache2/exportedlogs/apache/access.log common
+ErrorLog "|bin/rotatelogs -n 7 /usr/local/apache2/exportedlogs/apache/error.log 86400"
+CustomLog "|bin/rotatelogs -n 7 /usr/local/apache2/exportedlogs/apache/access.log 86400" common
 
 ExpiresActive On
 ExpiresDefault A604800
@@ -22,8 +22,8 @@ ExpiresByType text/css "access plus 10 hours"
 
 Listen 81
 <VirtualHost *:81>
-  ErrorLog /usr/local/apache2/exportedlogs/apache/admin-error.log
-  CustomLog /usr/local/apache2/exportedlogs/apache/admin-access.log common
+  ErrorLog "|bin/rotatelogs -n 7 /usr/local/apache2/exportedlogs/apache/admin-error.log 86400"
+  CustomLog "|bin/rotatelogs -n 7 /usr/local/apache2/exportedlogs/apache/admin-access.log 86400" common
   <IfModule mod_weblogic.c>
     WebLogicHost wladmin
     WebLogicPort 7001

--- a/chips-http.conf
+++ b/chips-http.conf
@@ -1,6 +1,6 @@
 ServerName apache
-ErrorLog "|bin/rotatelogs -n 7 /usr/local/apache2/exportedlogs/apache/error.log 86400"
-CustomLog "|bin/rotatelogs -n 7 /usr/local/apache2/exportedlogs/apache/access.log 86400" common
+ErrorLog "|bin/rotatelogs -t /usr/local/apache2/exportedlogs/apache/error.log 86400"
+CustomLog "|bin/rotatelogs -t /usr/local/apache2/exportedlogs/apache/access.log 86400" common
 
 ExpiresActive On
 ExpiresDefault A604800
@@ -22,8 +22,8 @@ ExpiresByType text/css "access plus 10 hours"
 
 Listen 81
 <VirtualHost *:81>
-  ErrorLog "|bin/rotatelogs -n 7 /usr/local/apache2/exportedlogs/apache/admin-error.log 86400"
-  CustomLog "|bin/rotatelogs -n 7 /usr/local/apache2/exportedlogs/apache/admin-access.log 86400" common
+  ErrorLog "|bin/rotatelogs -t /usr/local/apache2/exportedlogs/apache/admin-error.log 86400"
+  CustomLog "|bin/rotatelogs -t /usr/local/apache2/exportedlogs/apache/admin-access.log 86400" common
   <IfModule mod_weblogic.c>
     WebLogicHost wladmin
     WebLogicPort 7001


### PR DESCRIPTION
The apache logs were not being rotated, resulting in ever-increasing file sizes.  As the logs are ingested by CloudWatch on the fly, we can just truncate them at midnight rather than keeping archives of them on NFS.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1457