### PR TITLE
Disable Keep Alive and use default value for MaxSkipTime for WebLogic Plugin

### DIFF
--- a/chips-http.conf
+++ b/chips-http.conf
@@ -9,9 +9,9 @@ ExpiresByType text/css "access plus 10 hours"
 
 <IfModule mod_weblogic.c>
   WebLogicCluster wlserver1:7001,wlserver2:7001,wlserver3:7001,wlserver4:7001
-  MaxSkipTime 120
   WLSocketTimeoutSecs 20
   ConnectTimeoutSecs 30
+  KeepAliveEnabled OFF
   WLTempDir /tmp
   WLProxySSL ON
 </IfModule>


### PR DESCRIPTION
Remove the MaxSkipTime setting, so that it defaults to 10 secs, and set KeepAliveEnabled to OFF.

These settings are already in Live as a temporary fix, as we have been investigating an intermittent session loss problem and have found that these seem to eliminate the issue. We believe it is due to the Event MPM in use by Apache and its interactions with the WebLogic plugin.  We now need to commit the config change and release through the pipeline etc.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1461