### PR TITLE
Increase WLIOTimeoutSecs from 120 (default) to 300 secs

### DIFF
--- a/chips-http.conf
+++ b/chips-http.conf
@@ -12,6 +12,7 @@ ExpiresByType text/css "access plus 10 hours"
   WLSocketTimeoutSecs 20
   ConnectTimeoutSecs 30
   KeepAliveEnabled OFF
+  WLIOTimeoutSecs 300
   WLTempDir /tmp
   WLProxySSL ON
 </IfModule>


### PR DESCRIPTION
A further WebLogic apache plugin configuration tweak to increase the time allowed for a response from a WebLogic server node before the node is marked as "bad".  This is to allow for some very slow responses that still occur from time to time.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1461