### PR TITLE
Reference 1.2.0 of ch-apache base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN tar -xvf apache*.tar && \
     cd apache && \
     tar -xvf ../CHIPSviewer*.tar
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-apache:1.1.0
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-apache:1.2.0
 
 # Copy favicon.ico
 COPY favicon.ico htdocs

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN tar -xvf apache*.tar && \
     cd apache && \
     tar -xvf ../CHIPSviewer*.tar
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-apache:1.2.0
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-apache:1.1.1
 
 # Copy favicon.ico
 COPY favicon.ico htdocs


### PR DESCRIPTION
This brings in the check for the env var DISABLE_PROXY_SSL=true, which removes the `WLProxySSL ON` statements from the apache config files.
This allows CHIPS to function correctly when accessed without SSL, which is needed for the development environments.

Partially resolves:
https://companieshouse.atlassian.net/browse/CM-1511