### PR TITLE
Add URI patterns for saml2 and sso endpoints

### DIFF
--- a/chips-http.conf
+++ b/chips-http.conf
@@ -17,7 +17,7 @@ ExpiresByType text/css "access plus 10 hours"
   WLProxySSL ON
 </IfModule>
 
-<LocationMatch "(/chips/cff|/chips/cff/servlet/.+|/chips/cff.+|/chips/servlet/.+|/chips/utilities/.+|/chips-restService/.+|/chips-queuedRestService/.+)$">
+<LocationMatch "(/chips/cff|/chips/cff/servlet/.+|/chips/cff.+|/chips/servlet/.+|/chips/utilities/.+|/chips-restService/.+|/chips-queuedRestService/.+|/saml2/.+|/sso/.+)$">
   WLSRequest ON
 </LocationMatch>
 


### PR DESCRIPTION
Add patterns to allow Apache to forward on requests to the saml2 and sso endpoints.  

saml2 is built into Weblogic and is configured as part of the SAML2 integration, and the sso endpoint is the expected context path for a new sso web app that will be secured and accessed to force SSO login via Azure.

Partially resolves:
https://companieshouse.atlassian.net/browse/SUP-1129