### PR TITLE
Correct the pattern for the sso endpoint

### DIFF
--- a/chips-http.conf
+++ b/chips-http.conf
@@ -17,7 +17,7 @@ ExpiresByType text/css "access plus 10 hours"
   WLProxySSL ON
 </IfModule>
 
-<LocationMatch "(/chips/cff|/chips/cff/servlet/.+|/chips/cff.+|/chips/servlet/.+|/chips/utilities/.+|/chips-restService/.+|/chips-queuedRestService/.+|/saml2/.+|/sso.+)$">
+<LocationMatch "(/chips/cff|/chips/cff/servlet/.+|/chips/cff.+|/chips/servlet/.+|/chips/utilities/.+|/chips-restService/.+|/chips-queuedRestService/.+|/saml2/.+|/sso.*)$">
   WLSRequest ON
 </LocationMatch>
 

--- a/chips-http.conf
+++ b/chips-http.conf
@@ -17,7 +17,7 @@ ExpiresByType text/css "access plus 10 hours"
   WLProxySSL ON
 </IfModule>
 
-<LocationMatch "(/chips/cff|/chips/cff/servlet/.+|/chips/cff.+|/chips/servlet/.+|/chips/utilities/.+|/chips-restService/.+|/chips-queuedRestService/.+|/saml2/.+|/sso/.+)$">
+<LocationMatch "(/chips/cff|/chips/cff/servlet/.+|/chips/cff.+|/chips/servlet/.+|/chips/utilities/.+|/chips-restService/.+|/chips-queuedRestService/.+|/saml2/.+|/sso.+)$">
   WLSRequest ON
 </LocationMatch>
 


### PR DESCRIPTION
Removed the / from the pattern so that `<domain>/sso `can be used without needing to use `<domain>/sso/index.jsp`.

Partially resolves:
https://companieshouse.atlassian.net/browse/SUP-1129
