### PR TITLE
Prevent browser caching of /sso and /saml2/ endpoints

### DIFF
--- a/chips-http.conf
+++ b/chips-http.conf
@@ -17,8 +17,14 @@ ExpiresByType text/css "access plus 10 hours"
   WLProxySSL ON
 </IfModule>
 
-<LocationMatch "(/chips/cff|/chips/cff/servlet/.+|/chips/cff.+|/chips/servlet/.+|/chips/utilities/.+|/chips-restService/.+|/chips-queuedRestService/.+|/saml2/.+|/sso.*)$">
+<LocationMatch "(/chips/cff|/chips/cff/servlet/.+|/chips/cff.+|/chips/servlet/.+|/chips/utilities/.+|/chips-restService/.+|/chips-queuedRestService/.+)$">
   WLSRequest ON
+</LocationMatch>
+
+<LocationMatch "(/saml2/.+|/sso.*)$">
+  WLSRequest ON
+  Header Set Pragma "no-cache"
+  Header Set Cache-Control "max-age=0, no-store, no-cache, must-revalidate"
 </LocationMatch>
 
 Listen 81


### PR DESCRIPTION
During testing we found that the /sso endpoint can be cached in the browser, which results in the redirect to /chips/cff/ssologin happening without a fresh session being established.  If the session has expired due to inactivity/timeout, then the user can end up being directed to a different Weblogic node when they return from the Microsoft endpoint which was resulting in an Error 500.  
This fix adds headers to disable caching for the /sso* and /saml2/* endpoints, so there is always an active session.

Resolves:
https://companieshouse.atlassian.net/browse/SUP-1129