### PR TITLE
Add /chips/edgecff.* to match patterns for routing requests to Weblogic

### DIFF
--- a/chips-http.conf
+++ b/chips-http.conf
@@ -17,7 +17,7 @@ ExpiresByType text/css "access plus 10 hours"
   WLProxySSL ON
 </IfModule>
 
-<LocationMatch "(/chips/cff|/chips/cff/servlet/.+|/chips/cff.+|/chips/servlet/.+|/chips/utilities/.+|/chips/rest/.+|/chips-restService/.+|/chips-queuedRestService/.+)$">
+<LocationMatch "(/chips/cff|/chips/cff/servlet/.+|/chips/cff.+|/chips/edgecff.*|/chips/servlet/.+|/chips/utilities/.+|/chips/rest/.+|/chips-restService/.+|/chips-queuedRestService/.+)$">
   WLSRequest ON
 </LocationMatch>
 


### PR DESCRIPTION
Adds a pattern match, so that requests for `/chips/edgecff.*` are routed to the CHIPS java app running on Weblogic.  This will match /chips/edgecff, /chips/edgecff/ and /chips/edgecff/blah etc.

Resolves:
https://companieshouse.atlassian.net/browse/CHP-313