### PR TITLE
Only cache javascript files for 10 hours

### DIFF
--- a/chips-http.conf
+++ b/chips-http.conf
@@ -5,6 +5,7 @@ CustomLog "|bin/rotatelogs -t /usr/local/apache2/exportedlogs/apache/access.log 
 ExpiresActive On
 ExpiresDefault A604800
 ExpiresByType application/x-javascript "access plus 10 hours"
+ExpiresByType text/javascript "access plus 10 hours"
 ExpiresByType text/css "access plus 10 hours"
 
 <IfModule mod_weblogic.c>


### PR DESCRIPTION
We have found that the intended cache expiry of 10 hours for JavaScript files is not being applied due to an incorrect (or missing) mime/content type in the Apache config, so we have added an extra config line that covers most of the CHIPS javascript to correct this.

Resolves:
https://companieshouse.atlassian.net/browse/CHP-600