### PR TITLE
Set expiry time to 10 hours for text/html content type

### DIFF
--- a/chips-http.conf
+++ b/chips-http.conf
@@ -7,6 +7,7 @@ ExpiresDefault A604800
 ExpiresByType application/x-javascript "access plus 10 hours"
 ExpiresByType text/javascript "access plus 10 hours"
 ExpiresByType text/css "access plus 10 hours"
+ExpiresByType text/html "access plus 10 hours"
 
 <IfModule mod_weblogic.c>
   WebLogicCluster wlserver1:7001,wlserver2:7001,wlserver3:7001,wlserver4:7001


### PR DESCRIPTION
Updates the expiry time for html pages to 10 hours to match css & javascript files.

This is to avoid a mismatch between files that was encountered during the last CHIPS release, due to caching where we had to ask users to force refresh the content using Ctrl-Shift-r.

Resolves:
https://companieshouse.atlassian.net/browse/CHP-869