### PR TITLE
Update to WL14 ch-apache base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:1.2.5 as builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-oraclelinux:2.0.1 AS builder
 
 COPY apache*.tar CHIPSviewer*.tar ./
 
 RUN tar -xvf apache*.tar && \
-    cd apache && \
-    tar -xvf ../CHIPSviewer*.tar
+    tar -xvf CHIPSviewer*.tar -C apache
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-apache:1.1.2
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-apache:2.0.1
 
 # Copy favicon.ico
 COPY favicon.ico htdocs

--- a/chips-http.conf
+++ b/chips-http.conf
@@ -38,7 +38,7 @@ Listen 81
     ConnectTimeoutSecs 30
     WLTempDir /tmp
   </IfModule>
-  <LocationMatch "^/console/*">
+  <LocationMatch "^/console/*|^rconsole/*">
     WLSRequest ON
     WLProxySSL ON
   </LocationMatch>

--- a/chips-http.conf
+++ b/chips-http.conf
@@ -38,7 +38,7 @@ Listen 81
     ConnectTimeoutSecs 30
     WLTempDir /tmp
   </IfModule>
-  <LocationMatch "^/console/*|^rconsole/*">
+  <LocationMatch "^/console/*|^/rconsole/*">
     WLSRequest ON
     WLProxySSL ON
   </LocationMatch>

--- a/chips-http.conf
+++ b/chips-http.conf
@@ -40,6 +40,8 @@ Listen 81
     WLTempDir /tmp
   </IfModule>
   <LocationMatch "^/console/*|^/rconsole/*">
+    Header Set Pragma "no-cache"
+    Header Set Cache-Control "max-age=0, no-store, no-cache, must-revalidate"
     WLSRequest ON
     WLProxySSL ON
   </LocationMatch>

--- a/chips-http.conf
+++ b/chips-http.conf
@@ -51,3 +51,20 @@ Listen 81
     WLProxySSL ON
   </LocationMatch>
 </VirtualHost>
+
+<If "%{QUERY_STRING} =~ /^s=1$/">
+  WebLogicHost wlserver1
+  WebLogicPort 7001
+</If>
+<If "%{QUERY_STRING} =~ /^s=2$/">
+  WebLogicHost wlserver2
+  WebLogicPort 7001
+</If>
+<If "%{QUERY_STRING} =~ /^s=3$/">
+  WebLogicHost wlserver3
+  WebLogicPort 7001
+</If>
+<If "%{QUERY_STRING} =~ /^s=4$/">
+  WebLogicHost wlserver4
+  WebLogicPort 7001
+</If>


### PR DESCRIPTION
Reference the latest ch-oraclelinux & ch-apache base images to pull in the WL14 related changes.

This also adds the ability to control which Weblogic node is accessed, within the same cluster,  by appending a query param - e.g. to access wlserver2, then you could use a URL such as /chips/cff?s=2

Resolves:
https://companieshouse.atlassian.net/browse/CHP-1023