### PR TITLE
Update ch-apache base image to 2.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY apache*.tar CHIPSviewer*.tar ./
 RUN tar -xvf apache*.tar && \
     tar -xvf CHIPSviewer*.tar -C apache
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-apache:2.0.1
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-apache:2.0.3
 
 # Copy favicon.ico
 COPY favicon.ico htdocs


### PR DESCRIPTION
Reference 2.0.3 version of ch-apache base image to bring in the following:

Jan 2026 Weblogic/Java patches:
https://companieshouse.atlassian.net/browse/CHP-1000

